### PR TITLE
Add VS Code syntax highlight for Orus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Orus VS Code Extension
+
+This extension adds syntax highlighting support for the **Orus** programming language.
+
+Keywords and operators are highlighted similarly to Python and Rust. The language features are described in [`LANGUAGE.md`](./LANGUAGE.md) and the example programs under the `tests/` directory.
+
+## Features
+- Highlight keywords such as `fn`, `let`, `struct`, control flow statements and boolean operators.
+- Built-in types (`i32`, `u32`, `f64`, `bool`, `string`) and the `nil` value.
+- Comments beginning with `//`.
+- Strings and numeric literals.
+
+## Usage
+Install the extension from the VSIX package or clone this repository and run `vsce package` to build.
+
+Once installed, any file with the `.orus` extension will be highlighted automatically.

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,0 +1,58 @@
+{
+  "comments": {
+    "lineComment": "//"
+  },
+  "brackets": [
+    [
+      "{",
+      "}"
+    ],
+    [
+      "[",
+      "]"
+    ],
+    [
+      "(",
+      ")"
+    ]
+  ],
+  "autoClosingPairs": [
+    {
+      "open": "{",
+      "close": "}"
+    },
+    {
+      "open": "[",
+      "close": "]"
+    },
+    {
+      "open": "(",
+      "close": ")"
+    },
+    {
+      "open": "\"",
+      "close": "\"",
+      "notIn": [
+        "string"
+      ]
+    }
+  ],
+  "surroundingPairs": [
+    [
+      "{",
+      "}"
+    ],
+    [
+      "[",
+      "]"
+    ],
+    [
+      "(",
+      ")"
+    ],
+    [
+      "\"",
+      "\""
+    ]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "orus-lang",
+  "displayName": "Orus Language",
+  "description": "Syntax highlighting for the Orus programming language",
+  "version": "0.0.1",
+  "publisher": "orus",
+  "engines": {
+    "vscode": "^1.80.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "contributes": {
+    "languages": [
+      {
+        "id": "orus",
+        "aliases": [
+          "Orus",
+          "orus"
+        ],
+        "extensions": [
+          ".orus"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "orus",
+        "scopeName": "source.orus",
+        "path": "./syntaxes/orus.tmLanguage.json"
+      }
+    ]
+  },
+  "scripts": {
+    "test": "echo \"No tests specified\""
+  }
+}

--- a/syntaxes/orus.tmLanguage.json
+++ b/syntaxes/orus.tmLanguage.json
@@ -1,0 +1,101 @@
+{
+  "scopeName": "source.orus",
+  "name": "Orus",
+  "patterns": [
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#strings"
+    },
+    {
+      "include": "#numbers"
+    },
+    {
+      "include": "#keywords"
+    },
+    {
+      "include": "#types"
+    },
+    {
+      "include": "#builtins"
+    },
+    {
+      "name": "entity.name.type.struct.orus",
+      "match": "\\b[A-Z][A-Za-z0-9_]*\\b"
+    }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.double-slash.orus",
+          "match": "//.*$"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.orus",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "match": "\\\\.",
+              "name": "constant.character.escape.orus"
+            }
+          ]
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.float.orus",
+          "match": "\\b\\d+\\.\\d+\\b"
+        },
+        {
+          "name": "constant.numeric.integer.orus",
+          "match": "\\b\\d+\\b"
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.control.orus",
+          "match": "\\b(fn|return|let|struct|impl|for|in|while|if|elif|else|break|continue)\\b"
+        },
+        {
+          "name": "keyword.operator.logical.orus",
+          "match": "\\b(and|or|not)\\b"
+        },
+        {
+          "name": "constant.language.boolean.orus",
+          "match": "\\b(true|false|nil)\\b"
+        }
+      ]
+    },
+    "types": {
+      "patterns": [
+        {
+          "name": "storage.type.orus",
+          "match": "\\b(i32|u32|f64|bool|string)\\b"
+        }
+      ]
+    },
+    "builtins": {
+      "patterns": [
+        {
+          "name": "variable.language.self.orus",
+          "match": "\\bself\\b"
+        },
+        {
+          "name": "support.function.builtin.orus",
+          "match": "\\bprint\\b"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add extension manifest and simple README
- define language configuration for comments and brackets
- implement Orus TextMate grammar with keywords, types, and builtins