### PR TITLE
Improve string highlighting and add Rust-inspired theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Keywords and operators are highlighted similarly to Python and Rust. The languag
 - Module imports with the `use` keyword and type casting with the `as` keyword.
 - Comments with both `//` single-line and `/* */` block comment styles.
 - Strings with interpolation using `{}` placeholders and support for multi-line interpolation blocks.
+- Single and triple quoted strings for more flexible literals.
 - Array types and operations including slicing with `..` notation.
 - Compound assignment operators (`+=`, `-=`, `*=`, `/=`, `%=`).
 - Numeric literals for integers and floating-point values.
@@ -20,3 +21,6 @@ Keywords and operators are highlighted similarly to Python and Rust. The languag
 Install the extension from the VSIX package or clone this repository and run `vsce package` to build.
 
 Once installed, any file with the `.orus` extension will be highlighted automatically.
+
+## Color Theme
+This release bundles a `Orus Rust-Python` theme with colors inspired mostly by Rust but borrowing touches from Python themes. Activate it from the VS Code theme picker to get consistent highlighting across your Orus files.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "orus-lang",
   "displayName": "Orus Language",
   "description": "Syntax highlighting for the Orus programming language",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "icon": "logo/logo.png",
   "publisher": "orus",
   "license": "MIT",
@@ -39,6 +39,13 @@
         "language": "orus",
         "scopeName": "source.orus",
         "path": "./syntaxes/orus.tmLanguage.json"
+      }
+    ],
+    "themes": [
+      {
+        "label": "Orus Rust-Python",
+        "uiTheme": "vs-dark",
+        "path": "./themes/orus-color-theme.json"
       }
     ]
   },

--- a/syntaxes/orus.tmLanguage.json
+++ b/syntaxes/orus.tmLanguage.json
@@ -59,6 +59,14 @@
     "strings": {
       "patterns": [
         {
+          "name": "string.quoted.triple.orus",
+          "begin": "\"\"\"",
+          "end": "\"\"\"",
+          "patterns": [
+            { "match": "\\\\.", "name": "constant.character.escape.orus" }
+          ]
+        },
+        {
           "name": "string.quoted.double.orus",
           "begin": "\"",
           "end": "\"",
@@ -85,6 +93,14 @@
                 "0": { "name": "constant.character.format.placeholder.orus" }
               }
             }
+          ]
+        },
+        {
+          "name": "string.quoted.single.orus",
+          "begin": "'",
+          "end": "'",
+          "patterns": [
+            { "match": "\\\\.", "name": "constant.character.escape.orus" }
           ]
         }
       ]

--- a/themes/orus-color-theme.json
+++ b/themes/orus-color-theme.json
@@ -1,0 +1,38 @@
+{
+  "name": "Orus Rust-Python Mix",
+  "type": "dark",
+  "colors": {
+    "editor.background": "#1e1e1e",
+    "editor.foreground": "#d4d4d4"
+  },
+  "tokenColors": [
+    {
+      "scope": "comment",
+      "settings": { "foreground": "#6A9955" }
+    },
+    {
+      "scope": "string",
+      "settings": { "foreground": "#CE9178" }
+    },
+    {
+      "scope": "constant.numeric",
+      "settings": { "foreground": "#B5CEA8" }
+    },
+    {
+      "scope": "keyword",
+      "settings": { "foreground": "#569CD6" }
+    },
+    {
+      "scope": "storage.type",
+      "settings": { "foreground": "#4EC9B0" }
+    },
+    {
+      "scope": "support.function.builtin",
+      "settings": { "foreground": "#DCDC9A" }
+    },
+    {
+      "scope": "entity.name.function",
+      "settings": { "foreground": "#DCDCAA" }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- support triple and single quoted strings in Orus syntax
- add an Orus theme mixing Rust and Python colors
- expose the theme in `package.json`
- document new string features and theme usage
- bump extension version